### PR TITLE
Fix #2

### DIFF
--- a/LMC2PY.py
+++ b/LMC2PY.py
@@ -50,7 +50,8 @@ class LMC:
         # checks the extension and converts the file to mailbox machine code
 
         f = open(file_path).readlines()
-        os.chdir(ntpath.dirname(_filepath))
+        file_dir = ntpath.dirname(_filepath)
+        os.chdir(file_dir or '.')
         ext = file_path[-3:]
         if ext == 'lmc':
             self.mailboxes = f[1].split('%')[2].split(',')[:-1]

--- a/LMC2PY.py
+++ b/LMC2PY.py
@@ -50,8 +50,7 @@ class LMC:
         # checks the extension and converts the file to mailbox machine code
 
         f = open(file_path).readlines()
-        file_dir = ntpath.dirname(_filepath)
-        os.chdir(file_dir or '.')
+        os.chdir(ntpath.dirname(_filepath) or '.')
         ext = file_path[-3:]
         if ext == 'lmc':
             self.mailboxes = f[1].split('%')[2].split(',')[:-1]


### PR DESCRIPTION
I said I might do it tomorrow.

This fixes the issue I was having with the .lmc file being in the same directory as the .py file by replacing the string returned by ```ntpath.dirname()``` with ```'.'``` if it's empty.