### PR TITLE
Implement -b|--batch CLI arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a single file python script which runs the "Little Minion Computer" .lmc
 - Interprets LMC assembly and .LMC files to python
 - Test program against multiple inputs at once.
 - Test program against all inputs.
+- Test program using original LMC test files.
 - Check program outputs expected output.
 - Output graph of inputs vs F/E cycles for an easy visualisation of your programs efficiency.
 
@@ -23,6 +24,7 @@ This behaviour can be changed by the use of optional flags, which are put in pla
 - `-h`, `--help`: displays this list of options, instead of doing anything else. A source file is not needed in this case.
 - `-a`, `--all`: executes the program once for each value between 0 and 999.
 - `-i [VAL]`, `--input [VAL]`: executes the program once for each VAL given. Multiple inputs can be given as a list, like `-i 840 961 997`.
+- `-b [FILE]`, `--batch [FILE]`: Runs from any test file that is compatible with the original LMC and gives expected outputs based on those specified in this file.
 - `-q`, `--quiet`: executes the program without any terminal output, except errors. If you use this flag without any output flags, the program may not return anything.
 - `-f [FILE]`, `--feedback [FILE]`: save the results of the program to a text file. If no FILE is specified, this will be a file in the source file's directory called feedback_\<filename\>.
 - `-ch CHECKER`, `--checker CHECKER`: run a checker function from a python file with the same inputs as the LMC code, to show the expected output and see if your program's output matches. Some example checker functions are included in `checks/`.
@@ -31,3 +33,5 @@ This behaviour can be changed by the use of optional flags, which are put in pla
 ### Something to consider
 
 If your program requires multiple inputs, and it is passed a series of inputs using either `--all` or `--input`, it will use the next value from that series each time. If it runs out of inputs and then hits another IN statement, it will prompt you for another in the terminal.
+
+Furthermore, if you attempt to use both the `--batch` and `--checker` arguments at the same time, the expected outputs in the batch file will be used and the checker function will be ignored.

--- a/checks/divisors.py
+++ b/checks/divisors.py
@@ -2,15 +2,14 @@ def checker(inputs):
     n = inputs[0]
     f = 1
     factors = []
-    if n in [0,1]:
+    if n in [0, 1]:
         return [n]
-    while 1:
+    while f * f <= n:
         if n % f == 0:
             factors.append(f)
-            ndivf = n // f
-            if ndivf != f:
-                factors.append(ndivf)
+            n_div_f = n // f
+            if n_div_f != f:
+                factors.append(n_div_f)
         f += 1
-        if f * f > n:
-            break
+
     return sorted(factors)

--- a/lmc.py
+++ b/lmc.py
@@ -3,6 +3,10 @@ Handles the low-level running of LMC programs.
 """
 
 
+def get_input(text):
+    return input(text)
+
+
 class LMC:
     def __init__(self, _potential_values, mailboxes, max_cycles=50000):
         self.inputs = []
@@ -86,7 +90,7 @@ class LMC:
             self.neg_flag = 0
             self.accumulator = (self.potential_values or [None]).pop(0)
             if self.accumulator is None:
-                self.accumulator = int(input("Enter value: ")) % 1000
+                self.accumulator = int(get_input("Enter value: ")) % 1000
             self.inputs.append(self.accumulator)
         elif x == 2:
             self.outputs.append(self.accumulator)

--- a/lmc.py
+++ b/lmc.py
@@ -2,6 +2,7 @@
 Handles the low-level running of LMC programs.
 """
 
+
 class LMC:
     def __init__(self, _potential_values, mailboxes, max_cycles=50000):
         self.inputs = []

--- a/lmc2py.py
+++ b/lmc2py.py
@@ -16,6 +16,6 @@ elif args.all:
 else:
     potential_values = []
 
-lmc_wrapper = LMCWrapper(filepath, potential_values, 50000, checker_filepath, args)
+lmc_wrapper = LMCWrapper(filepath, potential_values, 50000, args)
 # lmc.print_mailboxes()
 lmc_wrapper.run_batch()

--- a/lmc_wrapper.py
+++ b/lmc_wrapper.py
@@ -2,12 +2,12 @@
 Handles the high-level running of LMC programs.
 """
 
+from lmc import LMC
 import importlib.util
 import ntpath
 import sys
 import os
 import re
-from lmc import LMC
 import plot
 
 
@@ -54,11 +54,10 @@ class LMCWrapper:
         print("Compiled program uses %d/100 mailboxes." % len(self.mailboxes))
         self.lmc = LMC(self.potential_values, self.mailboxes, self.max_cycles)
 
-    def get_checker(self, checker_filepath):
+    @staticmethod
+    def get_checker(checker_filepath):
         # gets the checker function at the given file_path.
-
         os.chdir(os.path.dirname(__file__))
-        # abs_path = os.path.abspath(checker_file_path)
         spec = importlib.util.spec_from_file_location("divisors.py", checker_filepath)
         foo = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(foo)

--- a/parsing.py
+++ b/parsing.py
@@ -14,12 +14,12 @@ parser.add_argument("file",
                     help="the file to execute; can be either LMC assembly (.txt or .asm) "
                          "or compiled LMC machine code (.lmc)")
 
-# input arguments; commented code is not yet implemented
+# input arguments
 i_group = parser.add_mutually_exclusive_group()
 i_group.add_argument("-a", "--all", action="store_true",
                      help="run the program for all inputs between 0 and 999 (recommend also using -q)")
-# i_group.add_argument("-b", "--batch",
-#                      help="a batch process file to test the program against")
+i_group.add_argument("-b", "--batch",
+                     help="a batch process file to test the program against")
 i_group.add_argument("-i", "--input", nargs="*", metavar="VAL",
                      help="one or more inputs to supply to the program, in order")
 
@@ -43,4 +43,5 @@ parser.add_argument("-ch", "--checker", help="filepath to file containing checke
 
 parser.add_argument("-g", "--graph", action="store_true",
                     help="show a scatter graph relating input to number of cycles")
+
 args = parser.parse_args()

--- a/unit_tests/test_lmc.py
+++ b/unit_tests/test_lmc.py
@@ -1,0 +1,129 @@
+import unittest
+from unittest.mock import patch
+from lmc import LMC
+
+
+class TestInput(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([], [])
+
+    @patch('lmc.get_input', return_value='5')
+    def test_in(self, input):
+        self.lmc.in_out(1)
+        self.assertEqual(self.lmc.accumulator, 5)
+        self.assertEqual(self.lmc.inputs, [5])
+        self.assertFalse(self.lmc.neg_flag)
+
+    @patch('lmc.get_input', return_value='-1')
+    def test_in_less_than_0(self, input):
+        self.lmc.in_out(1)
+        self.assertEqual(self.lmc.accumulator, 999)
+
+    @patch('lmc.get_input', return_value='1000')
+    def test_in_greater_than_999(self, input):
+        self.lmc.in_out(1)
+        self.assertEqual(self.lmc.accumulator, 0)
+
+    def in_potential_values(self):
+        lmc = LMC([1,5,3], [])
+        lmc.in_out(1)
+        self.assertEqual(lmc.accumulator, 1)
+        lmc.in_out(1)
+        self.assertEqual(lmc.accumulator, 5)
+        lmc.in_out(1)
+        self.assertEqual(lmc.accumulator, 3)
+
+
+class TestLda(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([], [555])
+
+    def test_lda(self):
+        self.lmc.lda(0)
+        self.assertEqual(self.lmc.accumulator, 555)
+        self.assertFalse(self.lmc.neg_flag)
+
+
+class TestBrz(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([], [])
+
+    def test_0(self):
+        self.lmc.accumulator = 0
+        self.lmc.brz(5)
+        self.assertEqual(self.lmc.counter, 5)
+
+    def test_not_0(self):
+        self.lmc.accumulator = 1
+        self.lmc.brz(5)
+        self.assertEqual(self.lmc.counter, 0)
+
+
+class TestBrp(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([], [])
+
+    def test_0(self):
+        self.lmc.accumulator = 0
+        self.lmc.brp(5)
+        self.assertEqual(self.lmc.counter, 5)
+
+    def test_greater_than_0(self):
+        self.lmc.accumulator = 1
+        self.lmc.brp(5)
+        self.assertEqual(self.lmc.counter, 5)
+
+    def test_neg_flag(self):
+        self.lmc.neg_flag = 1
+        self.lmc.brp(5)
+        self.assertEqual(self.lmc.counter, 0)
+
+
+class TestSub(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([], [555])
+
+    def test_b_less_than_a(self):
+        self.lmc.accumulator = 999
+        self.lmc.sub(0)
+        self.assertEqual(self.lmc.accumulator, 444)
+        self.assertFalse(self.lmc.neg_flag)
+
+    def test_b_greater_than_a(self):
+        self.lmc.accumulator = 100
+        self.lmc.sub(0)
+        self.assertEqual(self.lmc.accumulator, 545)
+        self.assertTrue(self.lmc.neg_flag)
+
+
+class TestAdd(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([], [555])
+
+    def test_add(self):
+        self.lmc.accumulator = 100
+        self.lmc.add(0)
+        self.assertEqual(self.lmc.accumulator, 655)
+
+    def test_add_overflow(self):
+        self.lmc.accumulator = 999
+        self.lmc.add(0)
+        self.assertEqual(self.lmc.accumulator, 554)
+
+
+class TestRunCycles(unittest.TestCase):
+    def setUp(self):
+        self.lmc = LMC([55], [901, 902, 105, 902,000, 100])
+
+    def TestExampleProgram(self):
+        inputs, outputs, num_cycles = self.lmc.run_cycles()
+        self.assertEqual(inputs, [55])
+        self.assertEqual(outputs, [55,155])
+        self.assertEqual(num_cycles, 5)
+        self.assertEqual(self.lmc.address_reg, 5)
+        self.assertEqual(self.lmc.counter, 6)
+        self.assertEqual(self.lm.accumulator, 5)
+        self.assertTrue(self.lmc.halted)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added the functionality to do `py2lmc.py filepath -b test_filepath`, with error checking if the test is not correctly written. Uses standard LMC test files. closes #3 
